### PR TITLE
Don't use `pkg_resources` on Python 3.11 and below.

### DIFF
--- a/iso_4217/lists.py
+++ b/iso_4217/lists.py
@@ -96,8 +96,7 @@ def _load_xml_resource(filename: str) -> bytes:
         from importlib.resources import files
 
         return files(__package__).joinpath("data/" + filename).read_bytes()
-    # Old python versions might miss
-    # argument-less files function, files function itself or resources modules
+    # Old python versions might miss files function or resources modules
     except (AttributeError, ImportError, TypeError):
         from pkg_resources import resource_string
 

--- a/iso_4217/lists.py
+++ b/iso_4217/lists.py
@@ -95,7 +95,7 @@ def _load_xml_resource(filename: str) -> bytes:
     try:
         from importlib.resources import files
 
-        return files().joinpath("data/" + filename).read_bytes()
+        return files(__package__).joinpath("data/" + filename).read_bytes()
     # Old python versions might miss
     # argument-less files function, files function itself or resources modules
     except (AttributeError, ImportError, TypeError):


### PR DESCRIPTION
Hi! The parameter in the `files()` call became optional only in Python 3.12 (see documentation for [current](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files) vs. [3.11](https://docs.python.org/3.11/library/importlib.resources.html#importlib.resources.files)), so in our Python 3.11 the library is falling back to `pkg_resources` import, which is [going to be removed real soon](https://github.com/pypa/setuptools/commit/05cb3c84f1422f3b26ccfb00f4c43886dc55b9bc#diff-e3d3d454fa3a072c9f46f8affa27513892fbc2d245e87f57a5927a7be851de05R100).

Adding the `__package__` as a parameter to `files()` fixes the issue and lets the library use `importlib`.